### PR TITLE
Add missing type attribute to <x/> form tag

### DIFF
--- a/src/mod_push.erl
+++ b/src/mod_push.erl
@@ -2191,8 +2191,17 @@ get_xdata_elements(Elements) ->
 
 get_xdata_elements([#xmlel{name = <<"x">>, attrs = Attrs} = H | T], Acc) ->
     case proplists:get_value(<<"xmlns">>, Attrs) of
-        ?NS_XDATA -> get_xdata_elements(T, [H|Acc]);
-        _ -> get_xdata_elements(T, Acc)
+        ?NS_XDATA ->
+            NewAttrs =
+            case fxml:get_attr(<<"type">>, Attrs) of
+                {value, _Type} ->
+                    Attrs;
+                false ->
+                    [{<<"type">>, <<"submit">>}|Attrs]
+            end,
+            get_xdata_elements(T, [H#xmlel{attrs = NewAttrs}|Acc]);
+        _ ->
+            get_xdata_elements(T, Acc)
     end;
 
 get_xdata_elements([_ | T], Acc) ->


### PR DESCRIPTION
The `<x/>` child of the `<enable/>` element in example 9 of [XEP-0357](http://xmpp.org/extensions/xep-0357.html) (v0.2) is missing a `type` attribute (which is [mandatory](http://xmpp.org/extensions/xep-0004.html#schema) according to [XEP-0004](http://xmpp.org/extensions/xep-0004.html), and [jlib:parse_xdata_submit/1](https://github.com/processone/ejabberd/blob/d40a091eda4a4a9d3d6c9e27ea4c0aeea2a7496d/src/jlib.erl#L402) insists on that attribute).
