### PR TITLE
Fix payload proplist for incoming notifications

### DIFF
--- a/src/mod_push.erl
+++ b/src/mod_push.erl
@@ -1102,9 +1102,14 @@ incoming_notification(_HookAcc, Node, [#xmlel{name = <<"notification">>,
                                 lists:foldl(
                                     fun({Key, Value}, Acc) ->
                                         case Value of
-                                            undefined -> Acc;
-                                            #jid{} -> jlib:jid_to_string(Value);
-                                            _ -> [{Key, Value}|Acc]
+                                            undefined ->
+                                                Acc;
+                                            #jid{} ->
+                                                JidStr =
+                                                jlib:jid_to_string(Value),
+                                                [{Key, JidStr}|Acc];
+                                            _ ->
+                                                [{Key, Value}|Acc]
                                         end
                                     end,
                                     [],


### PR DESCRIPTION
This fixes the following crash on incoming PubSub notifications:

```
{{json_encode, {bad_term, {struct, <<"user@example.com/Foo">>}}}, [{mochijson2, json_encode, 2, [{file, "src/mochijson2.erl"}, {line, 181}]}, {mod_push_gcm, payload_size_ok, 1, [{file, "src/mod_push_gcm.erl"}, {line, 244}]}, {mod_push_gcm, send_request, 4, [...]}]}
```
