### PR TITLE
Let node_push_publish_item hand over node name

### DIFF
--- a/src/node_push.erl
+++ b/src/node_push.erl
@@ -136,11 +136,11 @@ publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
         true ->
             VirtualNode = nodetree_virtual:get_node(Nidx),
             [{<<"">>, Host, <<"">>}] = VirtualNode#pubsub_node.owners,
-            NodeId = VirtualNode#pubsub_node.nodeid,
+            {_Host, Node} = VirtualNode#pubsub_node.nodeid,
             Result =
             ejabberd_hooks:run_fold(node_push_publish_item, Host,
                                     internal_server_error,
-                                    [NodeId, Payload, PubOpts]),
+                                    [Node, Payload, PubOpts]),
             ?DEBUG("+++++ node_push_publish_item hook result: ~p", [Result]),
             case Result of
                 ok -> {result, default};


### PR DESCRIPTION
Let the `node_push_publish_item` hook hand over the node name (as [expected](https://github.com/royneary/mod_push/blob/5ca7aad01699f20bb0980a3f56bc1aca7369847e/src/mod_push.erl#L1133) by `mod_push`) instead of the node ID tuple.
