### PR TITLE
README: remove "for now" qualifier on ejabberd requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mod_push is a project in the Google Summer of Code 2015 and is still pre-alpha. 
 * Erlang/OTP 17 or higher
 * If app server backends are used a working starttls configuration is required; by default the certificate set by the 'certfile' option will be used for communication with the push providers
 * for using APNS [this OTP fix](https://github.com/processone/otp/commit/45aaefe739c8ea6c33d140d056b94fcf53c3df30) is needed (see [this blog post](https://blog.process-one.net/apple-increasing-security-of-push-service-ahead-of-wwdc))
-* for now an [ejabberd branch](https://github.com/royneary/ejabberd/tree/mod_push_adjustments) with mod_push-specific modifications is needed
+* an [ejabberd branch](https://github.com/royneary/ejabberd/tree/mod_push_adjustments) with mod_push-specific modifications is needed
 
 ##Installation
 ```bash


### PR DESCRIPTION
This creates a lot of ambiguity around when "now" actually is or was,
whether it's `still true', etc. And it leads people to waste
both their own time and others' trying to determine
whether those changes have been integrated into the mainline ejabberd
in the intervening years between when the "for now" statement was first made
and the release of ejabberd that they're running, or whether
the statement is still actually current (which it is).